### PR TITLE
change image version to 9 and runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # Dockerfiles may only contain a FROM and the application data.
-# For Java applications use /ubi8/openjdk-11 or /ubi8/openjdk-17 as Base Image, for documentation 
+# For Java applications use /ubi9/openjdk-11-runtime or /ubi9/openjdk-17-runtime as Base Image, for documentation 
 # please see https://access.redhat.com/documentation/en-us/red_hat_jboss_middleware_for_openshift/3/html/red_hat_java_s2i_for_openshift/
 # All other variations must be approved by KM8
 
-FROM registry.access.redhat.com/ubi8/openjdk-17:latest
+FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:latest
 
 COPY target/*.jar /deployments/application.jar


### PR DESCRIPTION
**Description**

https://developers.redhat.com/articles/2021/05/24/build-lean-java-containers-new-red-hat-universal-base-images-openjdk-runtime#

Update das Image von ubi8 zu ubi9.

Wechsel zum Runtime, da das Image kleine ist, weil z.b. Maven fehlt. Die JAR Datei in der Pipeline gebaut wird  und nicht in diesem Dockerimage.

Intern können wir auch mal zu dem Image umstellen. 

Vor dem Merge sollte jemand das testen


