### PR TITLE
Update to advanced-security/policy-as-code@v2.3.6; added argument --d…

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Advance Security Policy as Code
-        uses: advanced-security/policy-as-code@v2.3.6
+        uses: advanced-security/policy-as-code@v2.4.0
         with:
           policy: it-at-m/policy-as-code
           policy-path: default.yaml

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,9 +11,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Advance Security Policy as Code
-        uses: advanced-security/policy-as-code@v2.3.4
+        uses: advanced-security/policy-as-code@v2.3.6
         with:
           policy: it-at-m/policy-as-code
           policy-path: default.yaml
           token: ${{ secrets.GITHUB_TOKEN }}
-          argvs: "--disable-dependabot --disable-secret-scanning --disable-code-scanning"
+          argvs: "--disable-dependabot --disable-secret-scanning --disable-code-scanning --display"


### PR DESCRIPTION
**Description**

* Change Version for Github Action advanced-security/policy-as-code from 2.3.4 to 2.3.6 
* Added argument --display to get output of failing packages
