### PR TITLE
[renovate] use config:recommended preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ]
+  "extends": ["config:recommended"]
 }


### PR DESCRIPTION
**Description**

`config:base` is deprecated, `config:recommended` is the way to go

**Reference**

https://docs.renovatebot.com/presets-config/#configrecommended
