### PR TITLE
Workflow for external builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Advance Security Policy as Code
-        uses: advanced-security/policy-as-code@v2.7.2
+        uses: advanced-security/policy-as-code@v2.7.1
         with:
           policy: it-at-m/policy-as-code
           policy-path: default.yaml

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,13 @@
-name: build and test
+name: Compliance check and build test
 
-on: [push]
+on: # defining on which triggers this action should run
+  push:
+    branches:
+      # define on push of which branches should this action be run
+    paths:
+      # define the concrete paths on which a change triggers this action, e.g. backend/**
+  pull_request: # trigger this action also on Pull Requests
+    types: [ opened, reopened ]
 
 jobs:
   compliance:
@@ -17,3 +24,19 @@ jobs:
           policy-path: default.yaml
           token: ${{ secrets.GITHUB_TOKEN }}
           argvs: "--disable-dependabot --disable-secret-scanning --disable-code-scanning --display"
+
+  build-maven:
+    needs: compliance
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: "17"
+          distribution: "temurin"
+          cache: "maven"
+
+      - name: Build with Maven
+        run: mvn --update-snapshots -f pom.xml verify

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: "17"
           distribution: "temurin"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Login to Registry
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
@@ -50,4 +50,4 @@ jobs:
         with:
           context: .
           push: true
-          tags:  ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,46 @@
+name: Build and publish an image
+
+on: # defining on which triggers this action should run
+  workflow_dispatch: # enable manual triggering of this action
+    inputs: # define the variables/inputs a user can set while triggering this action
+      input:
+        description: 'Example input'
+        required: true
+        default: 'none'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: "17"
+          distribution: "temurin"
+          cache: "maven"
+
+      - name: Build with Maven
+        run: mvn -B verify -f pom.xml -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_KEY }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: itatm/example-dockerhub-repository:example-tag

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,16 +8,22 @@ on: # defining on which triggers this action should run
         required: true
         default: 'none'
 
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
 jobs:
-  build:
+  build-push:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: "17"
           distribution: "temurin"
@@ -32,15 +38,16 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
+      - name: Login to Registry
+        uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_KEY }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push image
         uses: docker/build-push-action@v4
         with:
           context: .
           push: true
-          tags: itatm/example-dockerhub-repository:example-tag
+          tags:  ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}

--- a/.github/workflows/release-and-bump.yaml
+++ b/.github/workflows/release-and-bump.yaml
@@ -31,7 +31,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ steps.set-release-version.outputs.new_version }}
-          release_name: ${{ steps.set-release-version.outputs.new_version }}
+          name: ${{ steps.set-release-version.outputs.new_version }}
           draft: false
           prerelease: false
 

--- a/.github/workflows/release-and-bump.yaml
+++ b/.github/workflows/release-and-bump.yaml
@@ -41,8 +41,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Set Maven Project Version
         id: bump-snapshot-version

--- a/.github/workflows/release-and-bump.yaml
+++ b/.github/workflows/release-and-bump.yaml
@@ -54,6 +54,7 @@ jobs:
           mvn -B versions:set -DnewVersion=$new_version -f pom.xml
           git config --global user.email "github-actions@github.com"
           git config --global user.name "GitHub Actions"
+          git pull
           git add pom.xml
           git commit -m "Bump version to $new_version"
           git push

--- a/.github/workflows/release-and-bump.yaml
+++ b/.github/workflows/release-and-bump.yaml
@@ -10,11 +10,18 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Get Project Version
-        id: get-version
+        id: set-release-version
         run: |
           current_version=$(mvn help:evaluate -f pom.xml -Dexpression=project.version -q -DforceStdout)
+          echo "Current version: $current_version"
           new_version=$(echo $current_version | sed 's/-SNAPSHOT//')
           echo "New version: $new_version"
+          mvn -B versions:set -f pom.xml -DnewVersion=$new_version
+          git config --global user.email "github-actions@github.com"
+          git config --global user.name "GitHub Actions"
+          git add pom.xml
+          git commit -m "Bump version to $new_version"
+          git push
           echo "new_version=$new_version" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
@@ -23,8 +30,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ steps.get-version.outputs.new_version }}
-          release_name: ${{ steps.get-version.outputs.new_version }}
+          tag_name: ${{ steps.set-release-version.outputs.new_version }}
+          release_name: ${{ steps.set-release-version.outputs.new_version }}
           draft: false
           prerelease: false
 
@@ -37,7 +44,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set Maven Project Version
-        id: set-version
+        id: bump-snapshot-version
         run: |
           current_version=$(mvn help:evaluate -f pom.xml -Dexpression=project.version -q -DforceStdout)
           echo "Current version: $current_version"

--- a/.github/workflows/release-and-bump.yaml
+++ b/.github/workflows/release-and-bump.yaml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Create GitHub Release
         id: create_release
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release-and-bump.yaml
+++ b/.github/workflows/release-and-bump.yaml
@@ -41,6 +41,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set Maven Project Version
         id: bump-snapshot-version

--- a/.github/workflows/release-and-bump.yaml
+++ b/.github/workflows/release-and-bump.yaml
@@ -47,14 +47,14 @@ jobs:
       - name: Set Maven Project Version
         id: bump-snapshot-version
         run: |
+          git config --global user.email "github-actions@github.com"
+          git config --global user.name "GitHub Actions"
+          git pull
           current_version=$(mvn help:evaluate -f pom.xml -Dexpression=project.version -q -DforceStdout)
           echo "Current version: $current_version"
           new_version=$(echo $current_version | awk -F. -v OFS=. '{$3=$3+1; print $0"-SNAPSHOT"}')
           echo "New version: $new_version"
           mvn -B versions:set -DnewVersion=$new_version -f pom.xml
-          git config --global user.email "github-actions@github.com"
-          git config --global user.name "GitHub Actions"
-          git pull
           git add pom.xml
           git commit -m "Bump version to $new_version"
           git push

--- a/.github/workflows/release-and-bump.yaml
+++ b/.github/workflows/release-and-bump.yaml
@@ -53,6 +53,7 @@ jobs:
           mvn -B versions:set -DnewVersion=$new_version -f pom.xml
           git config --global user.email "github-actions@github.com"
           git config --global user.name "GitHub Actions"
+          git update
           git add pom.xml
           git commit -m "Bump version to $new_version"
           git push

--- a/.github/workflows/release-and-bump.yaml
+++ b/.github/workflows/release-and-bump.yaml
@@ -36,7 +36,7 @@ jobs:
           prerelease: false
 
   increase-snapshot:
-    needs: release
+    needs: github-release
     name: Increase patch-number of the SNAPSHOT-Version
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release-and-bump.yaml
+++ b/.github/workflows/release-and-bump.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get Project Version
         id: set-release-version
@@ -37,11 +37,10 @@ jobs:
 
   increase-snapshot:
     needs: github-release
-    name: Increase patch-number of the SNAPSHOT-Version
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set Maven Project Version
         id: bump-snapshot-version
@@ -53,7 +52,6 @@ jobs:
           mvn -B versions:set -DnewVersion=$new_version -f pom.xml
           git config --global user.email "github-actions@github.com"
           git config --global user.name "GitHub Actions"
-          git update
           git add pom.xml
           git commit -m "Bump version to $new_version"
           git push

--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -1,4 +1,4 @@
-name: Build GitHub release
+name: Build GitHub release and bump SNAPSHOT
 
 on: [workflow_dispatch] # enable manual triggering of this action
 

--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -1,0 +1,51 @@
+name: Build GitHub release
+
+on: [workflow_dispatch] # enable manual triggering of this action
+
+jobs:
+  github-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Get Project Version
+        id: get-version
+        run: |
+          current_version=$(mvn help:evaluate -f pom.xml -Dexpression=project.version -q -DforceStdout)
+          new_version=$(echo $current_version | sed 's/-SNAPSHOT//')
+          echo "New version: $new_version"
+          echo "new_version=$new_version" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.get-version.outputs.new_version }}
+          release_name: ${{ steps.get-version.outputs.new_version }}
+          draft: false
+          prerelease: false
+
+  increase-snapshot:
+    needs: release
+    name: Increase patch-number of the SNAPSHOT-Version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set Maven Project Version
+        id: set-version
+        run: |
+          current_version=$(mvn help:evaluate -f pom.xml -Dexpression=project.version -q -DforceStdout)
+          echo "Current version: $current_version"
+          new_version=$(echo $current_version | awk -F. -v OFS=. '{$3=$3+1; print $0"-SNAPSHOT"}')
+          echo "New version: $new_version"
+          mvn -B versions:set -DnewVersion=$new_version -f pom.xml
+          git config --global user.email "github-actions@github.com"
+          git config --global user.name "GitHub Actions"
+          git add pom.xml
+          git commit -m "Bump version to $new_version"
+          git push

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>de.muenchen</groupId>
     <artifactId>oss-repository-en-template</artifactId>
-    <version>0.0.2-SNAPSHOT</version>
+    <version>0.0.2</version>
     <name>oss-repository-en-template</name>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>de.muenchen</groupId>
     <artifactId>oss-repository-en-template</artifactId>
-    <version>0.0.2</version>
+    <version>0.0.1-SNAPSHOT</version>
     <name>oss-repository-en-template</name>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+
+
+    <groupId>de.muenchen</groupId>
+    <artifactId>oss-repository-en-template</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>oss-repository-en-template</name>
+
+
+    <properties>
+        <java.version>17</java.version>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
+        <maven.compiler.release>${java.version}</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven.compiler.plugin.version}</version>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>de.muenchen</groupId>
     <artifactId>oss-repository-en-template</artifactId>
-    <version>0.0.3-SNAPSHOT</version>
+    <version>0.0.1-SNAPSHOT</version>
     <name>oss-repository-en-template</name>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>de.muenchen</groupId>
     <artifactId>oss-repository-en-template</artifactId>
-    <version>0.0.1</version>
+    <version>0.0.2-SNAPSHOT</version>
     <name>oss-repository-en-template</name>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>de.muenchen</groupId>
     <artifactId>oss-repository-en-template</artifactId>
-    <version>0.0.1</version>
+    <version>0.0.1-SNAPSHOT</version>
     <name>oss-repository-en-template</name>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>de.muenchen</groupId>
     <artifactId>oss-repository-en-template</artifactId>
-    <version>0.0.2</version>
+    <version>0.0.3-SNAPSHOT</version>
     <name>oss-repository-en-template</name>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>de.muenchen</groupId>
     <artifactId>oss-repository-en-template</artifactId>
-    <version>0.0.2</version>
+    <version>0.0.2-SNAPSHOT</version>
     <name>oss-repository-en-template</name>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>de.muenchen</groupId>
     <artifactId>oss-repository-en-template</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.1</version>
     <name>oss-repository-en-template</name>
 
 


### PR DESCRIPTION
**Description**

In this PR three Workflows were created.

`Compliance check and build test`: This action has two jobs:
1. Compliance check with Policy as Code
2. Maven buiild with tests

`Build and publish an image`: This action performs a Maven build and pushen afterwards an image (`package`) to the GitHub Registry of the repository.

`Build GitHub release and bump SNAPSHOT`: This action has two jobs:
1. Setting the Maven version to the next non-SNAPSHOT one and creating a GitHub Tag and Release afterwerds with the new version. E.g. `0.0.2-SNAPSHOT` into `0.0.2` with Release and tag `0.0.2`
2. Increasing the project Maven version to the next SNAPSHOT version. E.g. `0.2.5` into `0.2.6-SNAPSHOT`

**Reference**

Issues https://git.muenchen.de/ccse/ospo/-/issues/264
Comment: https://git.muenchen.de/ccse/ospo/-/issues/264#note_732239
